### PR TITLE
fixes variable name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ SOMEFILE = 'path/to/a/ish/file'
 
 # read the file
 with open(SOMEFILE) as fp:
-  contents = fp.read()
+  content = fp.read()
 fp.close()
 
 wf = ish_parser()


### PR DESCRIPTION
Variable typo ’contents’ in tutorial/example corrected to ‘content’;
cross-checked with sh_parser_test.py for proper variable name
